### PR TITLE
Check casks in the existing Homebrew test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,22 @@ jobs:
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'
 
+      - name: Style and audit casks
+        run: |
+          shopt -s nullglob
+          casks=(Casks/*.rb)
+          if [ ${#casks[@]} -eq 0 ]; then
+            echo "No casks to check"
+            exit 0
+          fi
+
+          brew style --display-cop-names "${casks[@]}"
+
+          for cask in "${casks[@]}"; do
+            echo "Auditing ${cask}"
+            brew audit --cask --strict "$cask"
+          done
+
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- add cask style/audit checks to the existing `tests.yml` workflow
- keep `publish.yml` and `brew pr-pull` exactly as they already work today
- exit cleanly while the tap still has no `Casks/*.rb` files

## Notes
- companion source repo PR: wendylabsinc/wendy-agent#501
- this is the smallest tap-side change needed before WendyAgentMac release bumps start adding a cask next to the formula update