### PR TITLE
Defer shell completion install to `wendy completion install`

### DIFF
--- a/Formula/wendy-nightly.rb
+++ b/Formula/wendy-nightly.rb
@@ -33,13 +33,13 @@ class WendyNightly < Formula
     # Install macOS-specific bundle with resources (plist files, etc) if present
     bundle_path = "wendy-agent_wendy.bundle"
     (lib/"wendy").install bundle_path if File.directory?(bundle_path)
-
-    # Generate and install shell completions
-    generate_completions_from_executable(bin/"wendy", "completion")
   end
 
   def caveats
     <<~EOS
+      To install shell completions, run:
+        wendy completion install
+
       Attention: The Wendy CLI collects anonymous analytics.
       They help us understand which commands are used most, identify common errors, and prioritize improvements.
       Analytics are enabled by default. If you'd like to opt-out, use the following command:

--- a/Formula/wendy.rb
+++ b/Formula/wendy.rb
@@ -33,13 +33,13 @@ class Wendy < Formula
     # Install macOS-specific bundle with resources (plist files, etc) if present
     bundle_path = "wendy-agent_wendy.bundle"
     (lib/"wendy").install bundle_path if File.directory?(bundle_path)
-
-    # Generate and install shell completions
-    generate_completions_from_executable(bin/"wendy", "completion")
   end
 
   def caveats
     <<~EOS
+      To install shell completions, run:
+        wendy completion install
+
       Attention: The Wendy CLI collects anonymous analytics.
       They help us understand which commands are used most, identify common errors, and prioritize improvements.
       Analytics are enabled by default. If you'd like to opt-out, use the following command:


### PR DESCRIPTION
## Summary
- Drop `generate_completions_from_executable(bin/"wendy", "completion")` from both `Formula/wendy.rb` and `Formula/wendy-nightly.rb`.
- Add a caveat instructing users to run `wendy completion install` to set up shell completions.

## Why
[wendylabsinc/wendy-agent#626](https://github.com/wendylabsinc/wendy-agent/pull/626) introduced a `wendy completion install` subcommand that auto-detects the user's shell (`$SHELL` on Unix, `--shell` override available), writes the completion script to the shell's conventional location, and idempotently appends a sentinel-marked (`# wendy-completion`) block to the rc file when one is needed (`~/.bashrc` for bash fallback, `~/.zshrc` for zsh, PowerShell profile for pwsh). The shell-specific path knowledge lives in the CLI, so the formula should defer to it rather than reimplementing a parallel install path.

`generate_completions_from_executable` only captures stdout and writes to Homebrew's tracked completion directories, so it can't be reused for the new install flow (`wendy completion install` writes files itself). Removing the formula's auto-install also avoids `brew install` writing into Homebrew's prefix at the same time the user opts in to `wendy completion install`.

## Test plan
- [ ] `brew install --build-from-source ./Formula/wendy.rb` shows the new caveat
- [ ] `wendy completion install` (run by the user post-install) writes the expected script and rc-block per [PR #626](https://github.com/wendylabsinc/wendy-agent/pull/626)'s install-paths table

🤖 Generated with [Claude Code](https://claude.com/claude-code)