### PR TITLE
formula: use `wendy completion install --stdout` for completions

### DIFF
--- a/Casks/wendy-agent-nightly.rb
+++ b/Casks/wendy-agent-nightly.rb
@@ -7,5 +7,7 @@ cask "wendy-agent-nightly" do
   desc "Manage your headless device (nightly)"
   homepage "https://github.com/wendylabsinc/wendy-agent"
 
+  depends_on :macos
+
   app "WendyAgentMac.app"
 end

--- a/Casks/wendy-agent.rb
+++ b/Casks/wendy-agent.rb
@@ -7,5 +7,7 @@ cask "wendy-agent" do
   desc "Manage your headless device"
   homepage "https://github.com/wendylabsinc/wendy-agent"
 
+  depends_on :macos
+
   app "WendyAgentMac.app"
 end

--- a/Formula/wendy-nightly.rb
+++ b/Formula/wendy-nightly.rb
@@ -35,7 +35,11 @@ class WendyNightly < Formula
     (lib/"wendy").install bundle_path if File.directory?(bundle_path)
 
     # Generate and install shell completions
-    generate_completions_from_executable(bin/"wendy", "completion")
+    generate_completions_from_executable(
+      bin/"wendy",
+      "completion", "install", "--stdout",
+      shell_parameter_format: "--shell=%s",
+    )
   end
 
   def caveats

--- a/Formula/wendy-nightly.rb
+++ b/Formula/wendy-nightly.rb
@@ -38,7 +38,7 @@ class WendyNightly < Formula
     generate_completions_from_executable(
       bin/"wendy",
       "completion", "install", "--stdout",
-      shell_parameter_format: "--shell=%s"
+      shell_parameter_format: "--shell="
     )
   end
 

--- a/Formula/wendy-nightly.rb
+++ b/Formula/wendy-nightly.rb
@@ -38,7 +38,7 @@ class WendyNightly < Formula
     generate_completions_from_executable(
       bin/"wendy",
       "completion", "install", "--stdout",
-      shell_parameter_format: "--shell=%s",
+      shell_parameter_format: "--shell=%s"
     )
   end
 

--- a/Formula/wendy.rb
+++ b/Formula/wendy.rb
@@ -35,7 +35,11 @@ class Wendy < Formula
     (lib/"wendy").install bundle_path if File.directory?(bundle_path)
 
     # Generate and install shell completions
-    generate_completions_from_executable(bin/"wendy", "completion")
+    generate_completions_from_executable(
+      bin/"wendy",
+      "completion", "install", "--stdout",
+      shell_parameter_format: "--shell=%s",
+    )
   end
 
   def caveats

--- a/Formula/wendy.rb
+++ b/Formula/wendy.rb
@@ -38,7 +38,7 @@ class Wendy < Formula
     generate_completions_from_executable(
       bin/"wendy",
       "completion", "install", "--stdout",
-      shell_parameter_format: "--shell=%s"
+      shell_parameter_format: "--shell="
     )
   end
 

--- a/Formula/wendy.rb
+++ b/Formula/wendy.rb
@@ -38,7 +38,7 @@ class Wendy < Formula
     generate_completions_from_executable(
       bin/"wendy",
       "completion", "install", "--stdout",
-      shell_parameter_format: "--shell=%s",
+      shell_parameter_format: "--shell=%s"
     )
   end
 


### PR DESCRIPTION
## Summary
- Switch both `wendy` and `wendy-nightly` formulae to invoke `wendy completion install --stdout --shell=<shell>` (added in [wendy-agent#632](https://github.com/wendylabsinc/wendy-agent/pull/632)) instead of the Cobra-autogenerated `wendy completion <shell>` subcommand.
- Pass `shell_parameter_format: "--shell=%s"` so `generate_completions_from_executable` supplies the shell via the new flag rather than as a positional arg.

## Why
The bare `wendy completion install` subcommand writes scripts directly into the user's config locations and edits their shell rc files — fine for end-user installs, but not what Homebrew wants. PR #632 added `--stdout`, which makes `completion install` emit the script on stdout so `generate_completions_from_executable` can stage it under `bash_completion`, `zsh_completion`, and `fish_completion` without touching the filesystem. This gives the formulae a single, intent-revealing invocation instead of relying on the Cobra-generated subcommands.

## Test plan
- [ ] `brew install --build-from-source ./Formula/wendy.rb` (or `wendy-nightly.rb`) and confirm completions land in the expected `bash_completion` / `zsh_completion` / `fish_completion` directories.
- [ ] Verify a fresh shell picks up `wendy` completions for bash, zsh, and fish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)