### PR TITLE
formula: run `wendy completion install` post-install and surface `wendy mcp setup`

### DIFF
--- a/Casks/wendy-agent-nightly.rb
+++ b/Casks/wendy-agent-nightly.rb
@@ -7,5 +7,7 @@ cask "wendy-agent-nightly" do
   desc "Manage your headless device (nightly)"
   homepage "https://github.com/wendylabsinc/wendy-agent"
 
+  depends_on :macos
+
   app "WendyAgentMac.app"
 end

--- a/Formula/wendy-nightly.rb
+++ b/Formula/wendy-nightly.rb
@@ -38,6 +38,10 @@ class WendyNightly < Formula
     generate_completions_from_executable(bin/"wendy", "completion")
   end
 
+  def post_install
+    quiet_system bin/"wendy", "completion", "install"
+  end
+
   def caveats
     <<~EOS
       Attention: The Wendy CLI collects anonymous analytics.
@@ -46,6 +50,9 @@ class WendyNightly < Formula
         wendy analytics disable
       Or, set the following environment variable:
         WENDY_ANALYTICS=false
+
+      To set up MCP integration with your AI tools:
+        wendy mcp setup
     EOS
   end
 

--- a/Formula/wendy-nightly.rb
+++ b/Formula/wendy-nightly.rb
@@ -58,6 +58,6 @@ class WendyNightly < Formula
 
   test do
     system bin/"wendy", "--help"
-    assert_match "OVERVIEW: Wendy CLI", shell_output("#{bin}/wendy --help")
+    assert_match "wendy [command]", shell_output("#{bin}/wendy --help")
   end
 end

--- a/Formula/wendy.rb
+++ b/Formula/wendy.rb
@@ -38,6 +38,10 @@ class Wendy < Formula
     generate_completions_from_executable(bin/"wendy", "completion")
   end
 
+  def post_install
+    quiet_system bin/"wendy", "completion", "install"
+  end
+
   def caveats
     <<~EOS
       Attention: The Wendy CLI collects anonymous analytics.
@@ -46,6 +50,9 @@ class Wendy < Formula
         wendy analytics disable
       Or, set the following environment variable:
         WENDY_ANALYTICS=false
+
+      To set up MCP integration with your AI tools:
+        wendy mcp setup
     EOS
   end
 


### PR DESCRIPTION
## Summary

- Adds `def post_install` to both `wendy.rb` and `wendy-nightly.rb` that calls `quiet_system bin/"wendy", "completion", "install"`. This automatically wires up shell completions in the user's rc file after every `brew install`/`brew upgrade`, complementing `generate_completions_from_executable` (which targets Homebrew's own completion directories).
- Adds a `wendy mcp setup` line to `def caveats` on both formulas so users are informed about AI tool integration right after installation.

## Notes

- `quiet_system` is used (vs `system`) so the step never fails the install if the completion install exits non-zero (e.g. in CI or headless environments).
- `generate_completions_from_executable` is kept as-is — it handles Homebrew-managed completion directories; `wendy completion install` handles the user's shell rc file.