### PR TITLE
wendy: gate Apple `container` dep on macOS Tahoe+ (WDY-1800)

### DIFF
--- a/Formula/wendy-nightly.rb
+++ b/Formula/wendy-nightly.rb
@@ -29,7 +29,14 @@ class WendyNightly < Formula
     # The macOS CLI links libusb dynamically (cgo/gousb) for Jetson flashing.
     depends_on "libusb"
 
-    depends_on "container" => :recommended
+    # Apple `container` only ships bottles for macOS Tahoe (26) and newer.
+    # Gate the dependency on that — otherwise `brew install wendy-nightly`
+    # aborts on older macOS with "container: no bottle available!" (a Tier 3
+    # config), even though the pre-built wendy binary itself runs fine. wendy
+    # works without `container` via Docker or for remote-only device management.
+    on_tahoe :or_newer do
+      depends_on "container" => :recommended
+    end
   end
 
   conflicts_with "wendy", because: "both install a `wendy` binary"
@@ -68,13 +75,14 @@ class WendyNightly < Formula
     if OS.mac?
       s += <<~EOS
 
-        Local Linux containers on macOS are powered by Apple `container`
-        (installed by default with this formula). Before first use, start its
-        services once:
+        On macOS Tahoe (26) and newer, local Linux containers are powered by
+        Apple `container`, installed by default with this formula there. Before
+        first use, start its services once:
           container system start
           container builder start
         To skip installing it, reinstall with:
           brew install --without-container wendylabsinc/tap/wendy-nightly
+        (`container` has no bottle on older macOS, so it is not installed there.)
       EOS
     end
 

--- a/Formula/wendy.rb
+++ b/Formula/wendy.rb
@@ -28,7 +28,14 @@ class Wendy < Formula
     # The macOS CLI links libusb dynamically (cgo/gousb) for Jetson flashing.
     depends_on "libusb"
 
-    depends_on "container" => :recommended
+    # Apple `container` only ships bottles for macOS Tahoe (26) and newer.
+    # Gate the dependency on that — otherwise `brew install wendy` aborts on
+    # older macOS with "container: no bottle available!" (a Tier 3 config),
+    # even though the pre-built wendy binary itself runs fine. wendy works
+    # without `container` via Docker or for remote-only device management.
+    on_tahoe :or_newer do
+      depends_on "container" => :recommended
+    end
   end
 
   conflicts_with "wendy-nightly", because: "both install a `wendy` binary"
@@ -67,13 +74,14 @@ class Wendy < Formula
     if OS.mac?
       s += <<~EOS
 
-        Local Linux containers on macOS are powered by Apple `container`
-        (installed by default with this formula). Before first use, start its
-        services once:
+        On macOS Tahoe (26) and newer, local Linux containers are powered by
+        Apple `container`, installed by default with this formula there. Before
+        first use, start its services once:
           container system start
           container builder start
         To skip installing it, reinstall with:
           brew install --without-container wendylabsinc/tap/wendy
+        (`container` has no bottle on older macOS, so it is not installed there.)
       EOS
     end
 


### PR DESCRIPTION
## Problem

`brew install wendylabsinc/tap/wendy` (and `brew upgrade wendy`) aborted entirely on Macs older than Tahoe (26):

```
==> Would install 2 dependencies for wendy: libusb, container
Error: container: no bottle available!
This is a Tier 3 configuration: https://docs.brew.sh/Support-Tiers#tier-3
```

Both formulae declared `depends_on "container" => :recommended` unconditionally, and Homebrew installs recommended deps by default. Apple's `container` only ships bottles for recent macOS, so the whole wendy install failed — even though the pre-built wendy binary itself installs and runs fine. Hit in the field on 2026-07-02 (external user upgrading on an older-macOS arm64 Mac).

## Fix

Wrap the `container` dependency in `on_tahoe :or_newer` inside the existing `on_macos` block, in both `Formula/wendy.rb` and `Formula/wendy-nightly.rb`. `container` only powers the local Apple-Container build backend; wendy works without it via Docker or for remote-device-only use. The caveat wording now states the Tahoe+ condition so it is accurate on every macOS version.

## Why this won't regress on the next release

The wendy-agent release CI (`build.yml`) only **sed-patches the `url`/`sha256`/version lines** of the formula and fully regenerates the *agent app cask* (unrelated). It never touches the `depends_on` block — which is why the manually-added `container`/`libusb` lines have survived every prior version bump. So this gating lives durably in the formula and is not regenerated by CI. No wendy-agent change is required.

## Verification

`brew style` clean on both formulae. Dependency resolution simulated with `brew deps --os=<ver> --arch=arm` against the edited formula:

| Simulated OS | Dependencies |
|---|---|
| Tahoe (26) | `container` + `libusb` |
| Sequoia (15) | `libusb` only |
| Ventura (13) | `libusb` only |

## Acceptance

- [x] `brew install wendylabsinc/tap/wendy` succeeds on pre-Tahoe arm64 (no `container` attempted)
- [x] Tahoe+ unchanged (`container` installed by default; `--without-container` still opts out — it remains `:recommended`)
- [x] Fix is durable across releases (CI does not regenerate this block)

Closes WDY-1800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mhicL6SBzHqCa9VTahpGJ