### PR TITLE
wendy: bump to 2026.08.22-053704

### DIFF
--- a/Casks/wendy-agent.rb
+++ b/Casks/wendy-agent.rb
@@ -1,6 +1,6 @@
 cask "wendy-agent" do
-  version "2026.08.18-022337"
-  sha256 "166f22e487a40a7d4a6f27892e892a19d21ac6b34b49b335b13cef1aa9088f20"
+  version "2026.08.22-053704"
+  sha256 "39cc92312c7abc653c3df354206a571acbd0e7615ab85603252be1982adb84f3"
 
   url "https://github.com/wendylabsinc/wendy-agent/releases/download/#{version}/wendy-agent-macos-arm64-#{version}.zip"
   name "Wendy Agent"

--- a/Formula/wendy.rb
+++ b/Formula/wendy.rb
@@ -3,22 +3,22 @@ class Wendy < Formula
   homepage "https://github.com/wendylabsinc/wendy-agent"
 
   bottle do
-    root_url "https://github.com/wendylabsinc/homebrew-tap/releases/download/wendy-2026.08.18-022337"
+    root_url "https://github.com/wendylabsinc/homebrew-tap/releases/download/wendy-2026.08.22-053704"
     sha256 cellar: :any_skip_relocation, arm64_tahoe: "07f92ef72dba5a4dcc0519b4f1522a4d63b02def139e0e83f581e62b74496a61"
   end
 
   # Use pre-built binaries for all platforms
   if OS.mac?
     # macOS ARM64 only (signed and notarized)
-    url "https://github.com/wendylabsinc/wendy-agent/releases/download/2026.08.18-022337/wendy-cli-darwin-arm64-2026.08.18-022337.tar.gz"
-    sha256 "bc71df5b7bd911ded4aeb0e89019502753578cfa071f5fb900d3a9e52b7f1dc6"
+    url "https://github.com/wendylabsinc/wendy-agent/releases/download/2026.08.22-053704/wendy-cli-darwin-arm64-2026.08.22-053704.tar.gz"
+    sha256 "3b2afb206ed277cabe33bcd6226ad131ac0950570bc00172dbe400a4eaae5e05"
   elsif OS.linux?
     if Hardware::CPU.arm?
-      url "https://github.com/wendylabsinc/wendy-agent/releases/download/2026.08.18-022337/wendy-cli-linux-arm64-2026.08.18-022337.tar.gz"
-      sha256 "24de7df44a782c8e0f4f1728f2a7ee9b7e03c269d5d67a1690b1d60e0551aad4"
+      url "https://github.com/wendylabsinc/wendy-agent/releases/download/2026.08.22-053704/wendy-cli-linux-arm64-2026.08.22-053704.tar.gz"
+      sha256 "18ce8a3f8f8a3dc5714bda108e3ac34b9a9287e7ecc95795f15b7704d4130364"
     else
-      url "https://github.com/wendylabsinc/wendy-agent/releases/download/2026.08.18-022337/wendy-cli-linux-amd64-2026.08.18-022337.tar.gz"
-      sha256 "e16da9b75cdadf045e4264d0aacdec95cbdceddba7c006f4595ea7f340938025"
+      url "https://github.com/wendylabsinc/wendy-agent/releases/download/2026.08.22-053704/wendy-cli-linux-amd64-2026.08.22-053704.tar.gz"
+      sha256 "821c776bd61c67cf34c8e8baf60e1d384fd353182cf5a146e8fe030cc1afab91"
     end
   end
 


### PR DESCRIPTION
Stable has been four days behind the release. `brew upgrade wendy` reports *"already installed"* on `2026.08.18-022337`, so anyone on Homebrew cannot get features that have since shipped and merged:

- `wendy run --build-host <device>` could not reach a build host over the cloud tunnel (WendyOS #1729) — the flag existed but failed for any remote developer, which is the case it was written for
- `wendy run --device a,b,c` (one build, many devices) did not exist at all (WendyOS #1731–#1734, #1743)

`wendy-nightly` is already on this version (8f2d9fe), so this only affects the stable formula.

## What changed

Same shape as the previous bump (3440883): `root_url`, the three `url` + `sha256` pairs in `Formula/wendy.rb`, and `version` + `sha256` in `Casks/wendy-agent.rb`.

The bottle `sha256` is deliberately left stale for the follow-up bottle commit, matching how 3440883 was followed by 01ef7c3.

## On the checksums

These are the digests **GitHub reports** for the release assets, not values recomputed locally:

| asset | sha256 |
|---|---|
| `wendy-cli-darwin-arm64` | `3b2afb206ed277cabe33bcd6226ad131ac0950570bc00172dbe400a4eaae5e05` |
| `wendy-cli-linux-arm64` | `18ce8a3f8f8a3dc5714bda108e3ac34b9a9287e7ecc95795f15b7704d4130364` |
| `wendy-cli-linux-amd64` | `821c776bd61c67cf34c8e8baf60e1d384fd353182cf5a146e8fe030cc1afab91` |
| `wendy-agent-macos-arm64.zip` (cask) | `39cc92312c7abc653c3df354206a571acbd0e7615ab85603252be1982adb84f3` |

Worth stating because the obvious approach nearly went wrong: a first download was cut short at 8.4 MB of an 11.3 MB asset and hashed perfectly cleanly. Using that value would have produced a formula that refuses to install, with a checksum mismatch pointing at the release rather than at the formula.

## Checks

`ruby -c` passes on both files. Not installed from this branch locally — the bottle is stale until the follow-up commit, so a local install would build from the URL rather than exercise what users will get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)